### PR TITLE
Update Leagues and NewDataAccessObject bug fixes

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -116,10 +116,10 @@ public class AppBuilder {
 
     // thought question: is the hard dependency below a problem?
     //private final InMemoryUserDataAccessObject userDataAccessObject = new InMemoryUserDataAccessObject();
-    private final NewPantryUserDataAccessObject userDataAccessObject = new NewPantryUserDataAccessObject(userFactory);
-    private final NewPantryLeagueDataAccessObject leagueDataAccessObject = new NewPantryLeagueDataAccessObject();
-    //private final PantryUserDataAccessObject userDataAccessObject = new PantryUserDataAccessObject(userFactory);
-    //private final PantryLeagueDataAccessObject leagueDataAccessObject = new PantryLeagueDataAccessObject(leagueFactory);
+    //private final NewPantryUserDataAccessObject userDataAccessObject = new NewPantryUserDataAccessObject(userFactory);
+    //private final NewPantryLeagueDataAccessObject leagueDataAccessObject = new NewPantryLeagueDataAccessObject();
+    private final PantryUserDataAccessObject userDataAccessObject = new PantryUserDataAccessObject(userFactory);
+    private final PantryLeagueDataAccessObject leagueDataAccessObject = new PantryLeagueDataAccessObject(leagueFactory);
     //uncomment the line above in order to use the Pantry API userDAO :)
     private SignupView signupView;
     private SignupViewModel signupViewModel;

--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -116,10 +116,10 @@ public class AppBuilder {
 
     // thought question: is the hard dependency below a problem?
     //private final InMemoryUserDataAccessObject userDataAccessObject = new InMemoryUserDataAccessObject();
-    //private final NewPantryUserDataAccessObject userDataAccessObject = new NewPantryUserDataAccessObject(userFactory);
-    //private final NewPantryLeagueDataAccessObject leagueDataAccessObject = new NewPantryLeagueDataAccessObject();
-    private final PantryUserDataAccessObject userDataAccessObject = new PantryUserDataAccessObject(userFactory);
-    private final PantryLeagueDataAccessObject leagueDataAccessObject = new PantryLeagueDataAccessObject(leagueFactory);
+    private final NewPantryUserDataAccessObject userDataAccessObject = new NewPantryUserDataAccessObject(userFactory);
+    private final NewPantryLeagueDataAccessObject leagueDataAccessObject = new NewPantryLeagueDataAccessObject();
+    //private final PantryUserDataAccessObject userDataAccessObject = new PantryUserDataAccessObject(userFactory);
+    //private final PantryLeagueDataAccessObject leagueDataAccessObject = new PantryLeagueDataAccessObject(leagueFactory);
     //uncomment the line above in order to use the Pantry API userDAO :)
     private SignupView signupView;
     private SignupViewModel signupViewModel;

--- a/src/main/java/data_access/NewPantryLeagueDataAccessObject.java
+++ b/src/main/java/data_access/NewPantryLeagueDataAccessObject.java
@@ -6,6 +6,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import use_case.update_leagues.UpdateLeaguesLeagueDataAccessInterface;
+import use_case.update_rankings.UpdateRankingsLeagueDataAccessInterface;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,7 +14,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataAccessInterface {
+public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataAccessInterface,
+        UpdateRankingsLeagueDataAccessInterface {
 
 
     private static final int SUCCESS_CODE = 200;
@@ -40,13 +42,22 @@ public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataA
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
+    }
 
+    //should probably be combined into one: getLeague so less API calls?
+    @Override
+    public ArrayList<String> getLeagueUsers(String leagueID) {
+        return null;
+    }
+
+    @Override
+    public HashMap<String, String[]> getData(String leagueID) {
+        return null;
     }
 
     @Override
     public void saveNewLeague(String leagueID, String username) {
         if(leagueID.equals("")){
-            System.out.println("here");
             return;
         }
 
@@ -79,10 +90,12 @@ public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataA
         for(int i = 0; i < jsonUsers.length(); i++) {
             usernames.add(jsonUsers.getString(i));
         }
+        usernames.add(username);
         leagueData.put(USERS, usernames);
         save(allLeagueData);
     }
 
+    //prevents multiple calls to get
     @Override
     public ArrayList<League> getLeagues(ArrayList<String> userLeagueIDList) {
         ArrayList<League> leagues = new ArrayList<>();
@@ -107,7 +120,7 @@ public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataA
 
     //gets entire basket (all league data)
     public JSONObject get() {
-        sleep(2);
+        sleep(3);
         // Make an API call to get the user object.
         final String fullURL = API_URL + key + "/basket/" + BASKET_NAME;
         final OkHttpClient client = new OkHttpClient().newBuilder().build();
@@ -153,7 +166,7 @@ public class NewPantryLeagueDataAccessObject implements UpdateLeaguesLeagueDataA
                 System.out.println("saved league data");
             } else {
                 System.out.println("failed to save league data");
-                throw new RuntimeException("Failed to update leagues: " + response.message());
+                throw new RuntimeException("failed to update league: " + response.message());
             }
         } catch (IOException | JSONException ex) {
             throw new RuntimeException("Error", ex);

--- a/src/main/java/data_access/NewPantryUserDataAccessObject.java
+++ b/src/main/java/data_access/NewPantryUserDataAccessObject.java
@@ -14,6 +14,7 @@ import use_case.logout.LogoutUserDataAccessInterface;
 import use_case.signup.SignupUserDataAccessInterface;
 import use_case.solo_play.SoloPlayUserDataAccessInterface;
 import use_case.update_leagues.UpdateLeaguesUserDataAccessInterface;
+import use_case.update_rankings.UpdateRankingsUserDataAccessInterface;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -29,7 +30,8 @@ public class NewPantryUserDataAccessObject implements SignupUserDataAccessInterf
                                                         LogoutUserDataAccessInterface,
                                                         SoloPlayUserDataAccessInterface,
                                                         AddFriendsUserDataAccessInterface,
-                                                        UpdateLeaguesUserDataAccessInterface {
+                                                        UpdateLeaguesUserDataAccessInterface,
+                                                        UpdateRankingsUserDataAccessInterface {
     private static final int SUCCESS_CODE = 200;
     private static final String CONTENT_TYPE_LABEL = "Content-Type";
     private static final String CONTENT_TYPE_JSON = "application/json";
@@ -216,7 +218,7 @@ public class NewPantryUserDataAccessObject implements SignupUserDataAccessInterf
                 System.out.println("saved user data");
             } else {
                 System.out.println("failed to save user data");
-                throw new RuntimeException("Failed to update user: " + response.message());
+                throw new RuntimeException("failed to save user: " + response.message());
             }
         } catch (IOException | JSONException ex) {
             throw new RuntimeException("Error", ex);

--- a/src/main/java/data_access/NewPantryUserDataAccessObject.java
+++ b/src/main/java/data_access/NewPantryUserDataAccessObject.java
@@ -103,6 +103,17 @@ public class NewPantryUserDataAccessObject implements SignupUserDataAccessInterf
     }
 
     @Override
+    public boolean userInLeague(String username, String leagueID) {
+        JSONObject allUserData = get();
+        JSONObject userData = allUserData.getJSONObject(username);
+        JSONArray jsonLeagues = userData.getJSONArray(LEAGUES);
+        if(toArrayList(jsonLeagues).contains(leagueID)){
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public void changePassword(User user) {
         JSONObject allUserData = get();
         JSONObject userData = allUserData.getJSONObject(user.getName());
@@ -231,5 +242,13 @@ public class NewPantryUserDataAccessObject implements SignupUserDataAccessInterf
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public <T> ArrayList<T> toArrayList(JSONArray jsonArray){
+        ArrayList<T> arrayList = new ArrayList<>();
+        for(int i = 0; i < jsonArray.length(); i++){
+            arrayList.add((T) jsonArray.get(i));
+        }
+        return arrayList;
     }
 }

--- a/src/main/java/data_access/PantryUserDataAccessObject.java
+++ b/src/main/java/data_access/PantryUserDataAccessObject.java
@@ -44,7 +44,7 @@ public class PantryUserDataAccessObject implements SignupUserDataAccessInterface
         AddFriendsUserDataAccessInterface,
         DraftUserDataAccessInterface,
         UpdateLeaguesUserDataAccessInterface,
-        UpdateRankingsUserDataAccessInterface {
+        UpdateRankingsUserDataAccessInterface{
 
     private static final int SUCCESS_CODE = 200;
     private static final String CONTENT_TYPE_LABEL = "Content-Type";
@@ -296,5 +296,10 @@ public class PantryUserDataAccessObject implements SignupUserDataAccessInterface
     @Override
     public ArrayList<String> addLeague(String username, String leagueID) {
         return null;
+    }
+
+    @Override
+    public boolean userInLeague(String username, String leagueID) {
+        return false;
     }
 }

--- a/src/main/java/use_case/update_leagues/UpdateLeaguesInteractor.java
+++ b/src/main/java/use_case/update_leagues/UpdateLeaguesInteractor.java
@@ -25,11 +25,12 @@ public class UpdateLeaguesInteractor implements UpdateLeaguesInputBoundary{
         ArrayList<String> userLeagueIDList;
         //join league
         if(updateLeaguesInputData.isJoin()){
+            System.out.println("here");
             if (!leagueDataAccessObject.LeagueExists(leagueID)) {
                 updateLeaguesPresenter.prepareFailView("League Does Not Exist");
                 return;
             }
-            //update user league list & returns updated list of leagues
+            //update user league list & returns list of leagues
             userLeagueIDList = userDataAccessObject.addLeague(username,  leagueID);
             //update league's list of users
             leagueDataAccessObject.addUserToLeague(leagueID, username);
@@ -47,7 +48,6 @@ public class UpdateLeaguesInteractor implements UpdateLeaguesInputBoundary{
         }
         //no leagues, then keep original view, so no presenter needed
         if(userLeagueIDList.isEmpty()){
-            System.out.println("empty");
             return;
         }
         ArrayList<League> userLeagueList = leagueDataAccessObject.getLeagues(userLeagueIDList);

--- a/src/main/java/use_case/update_leagues/UpdateLeaguesInteractor.java
+++ b/src/main/java/use_case/update_leagues/UpdateLeaguesInteractor.java
@@ -22,12 +22,20 @@ public class UpdateLeaguesInteractor implements UpdateLeaguesInputBoundary{
     public void execute(UpdateLeaguesInputData updateLeaguesInputData) {
         String username = updateLeaguesInputData.getUsername();
         String leagueID = updateLeaguesInputData.getLeagueID();
+
+        boolean leagueExists = leagueDataAccessObject.LeagueExists(leagueID);
+        boolean userInLeague = userDataAccessObject.userInLeague(username, leagueID);
+
+
         ArrayList<String> userLeagueIDList;
         //join league
         if(updateLeaguesInputData.isJoin()){
-            System.out.println("here");
-            if (!leagueDataAccessObject.LeagueExists(leagueID)) {
+            if (!leagueExists) {
                 updateLeaguesPresenter.prepareFailView("League Does Not Exist");
+                return;
+            }
+            if(userInLeague){
+                updateLeaguesPresenter.prepareFailView("Already In League");
                 return;
             }
             //update user league list & returns list of leagues
@@ -37,7 +45,7 @@ public class UpdateLeaguesInteractor implements UpdateLeaguesInputBoundary{
         }
         //create league (if not joining, then creating)
         else{
-            if (leagueDataAccessObject.LeagueExists(leagueID)) {
+            if (leagueExists) {
                 updateLeaguesPresenter.prepareFailView("League Already Exists");
                 return;
             }

--- a/src/main/java/use_case/update_leagues/UpdateLeaguesUserDataAccessInterface.java
+++ b/src/main/java/use_case/update_leagues/UpdateLeaguesUserDataAccessInterface.java
@@ -7,4 +7,5 @@ import java.util.ArrayList;
 
 public interface UpdateLeaguesUserDataAccessInterface {
     ArrayList<String> addLeague(String username, String leagueID);
+    boolean userInLeague(String username, String leagueID);
 }

--- a/src/main/java/view/LeagueView.java
+++ b/src/main/java/view/LeagueView.java
@@ -109,7 +109,7 @@ public class LeagueView  extends JPanel implements ActionListener, PropertyChang
                     if (evt.getSource().equals(joinLeagueButton)) {
                         String username = leagueViewModel.getState().getUsername();
                         leagueViewModel.getState().setErrorMessage(null);
-                        updateLeaguesController.execute(username, createLeagueID.getText(), true);
+                        updateLeaguesController.execute(username, joinLeagueID.getText(), true);
                     }
                 }
         );

--- a/src/main/java/view/LoggedInView.java
+++ b/src/main/java/view/LoggedInView.java
@@ -57,7 +57,7 @@ public class LoggedInView extends JPanel implements PropertyChangeListener {
         soloPlay = new JButton(LoggedInViewModel.SOLO_PLAY_LABEL);
         buttons.add(soloPlay);
 
-        toLeague = new JButton("My League");
+        toLeague = new JButton("My Leagues");
         buttons.add(toLeague);
 
         toRankings = new JButton("Rankings");


### PR DESCRIPTION
-got update leagues to be (completely?) functioning using NewPantryUserDataAccessObject & NewPantryLeagueDataAccessObject

-update_leagues use case only works with these new data accessors, have to switch to them in app builder to see, rest of completed use_cases should still function with the new data accessors since it implements them & I did the methods (could be bugs?)

-if we decide to switch to a new JSON database, only methods we need to change in NewPantryUserDataAccessObject & NewPantryLeagueDataAccessObject are .get() and .set(JSONObject jsonObject)

-calls fail view when trying to join league twice

